### PR TITLE
feat: Add StringListConverter for List<String> to String conversion i…

### DIFF
--- a/src/main/java/com/team/hospital/api/patient/PatientController.java
+++ b/src/main/java/com/team/hospital/api/patient/PatientController.java
@@ -81,14 +81,14 @@ public class PatientController {
         if (year == null && month == null) {
             // 수술명으로 조회
             if (opName != null) {
-                patients = patientService.findPatientsByOperationTypeName(opName, pageable).getContent();
+                patients = patientService.findPatientsByOperationTypeNameContaining(opName, pageable).getContent();
             } else {
                 patients = patientService.findAll(pageable).getContent();
             }
         }
         if (year != null && month == null) {
             if (opName != null) {
-                patients = patientService.findPatientsByOperationTypeName(opName, pageable).stream()
+                patients = patientService.findPatientsByOperationTypeNameContaining(opName, pageable).stream()
                         .filter(patient -> patient.getOperationDate().getYear() == year)
                         .toList();
             } else {
@@ -97,7 +97,7 @@ public class PatientController {
         }
         if (year != null && month != null) {
             if (opName != null) {
-                patients = patientService.findPatientsByOperationTypeName(opName, pageable).stream()
+                patients = patientService.findPatientsByOperationTypeNameContaining(opName, pageable).stream()
                         .filter(patient -> patient.getOperationDate().getYear() == year && patient.getOperationDate().getMonthValue() == month)
                         .toList();
             } else {

--- a/src/main/java/com/team/hospital/api/patient/PatientService.java
+++ b/src/main/java/com/team/hospital/api/patient/PatientService.java
@@ -78,7 +78,7 @@ public class PatientService {
         return patientRepository.findPatientsByYearAndOpNameContaining(year, operationTypeName,pageable);
     }
 
-    public Slice<Patient> findPatientsByOperationTypeName(String operationName, Pageable pageable) {
+    public Slice<Patient> findPatientsByOperationTypeNameContaining(String operationName, Pageable pageable) {
         return patientRepository.findPatientsByOperationTypeNameContaining(operationName, pageable);
     }
 


### PR DESCRIPTION
…n JPA

- Implemented `StringListConverter` to handle conversion between `List<String>` and `String` for JPA entity attributes.
- Uses a comma separator to join and split list elements for database storage and retrieval.

This addition enables seamless storage of `List<String>` attributes as a single delimited string in the database.